### PR TITLE
Enhance configurability, improve OpenShift compatibility

### DIFF
--- a/templates/bootstrap-job.yaml
+++ b/templates/bootstrap-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.bootstrap.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -90,4 +91,4 @@ spec:
       {{- end }}
       restartPolicy: Never
   backoffLimit: 4
-
+{{- end }}

--- a/templates/bootstrap-job.yaml
+++ b/templates/bootstrap-job.yaml
@@ -77,17 +77,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.bootstrap.containerSecurityContext }}
         securityContext:
-          runAsUser: 65532
-          runAsGroup: 65532
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: arkime-config
         configMap:

--- a/templates/deployment-central-viewer.yaml
+++ b/templates/deployment-central-viewer.yaml
@@ -108,6 +108,53 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+      {{- if .Values.multies.enabled | default false }}
+      - name: multies
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        command: 
+          {{- toYaml .Values.multies.command | nindent 10 }}
+        {{- if .Values.multies.args }}
+        args: 
+          {{- toYaml .Values.multies.args | nindent 10 }}
+        {{- end }}
+        env:
+          {{- if .Values.multies.env }}
+            {{- toYaml .Values.multies.env | nindent 10 }}
+          {{- end }}
+          {{- if .Values.multies.envFrom }}
+        envFrom:
+          {{- toYaml .Values.multies.envFrom | nindent 10 }}
+          {{- end }}
+        ports:
+          - name: multies
+            containerPort: {{ .Values.multies.port | default 8200 }}
+        volumeMounts:
+          - name: arkime-config
+            mountPath: /opt/arkime/etc/config.ini
+            subPath: config.ini
+        {{- with .Values.multies.resources }}
+        resources: 
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.multies.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+      {{- end }}
       volumes:
       - name: arkime-config
         configMap:

--- a/templates/deployment-central-viewer.yaml
+++ b/templates/deployment-central-viewer.yaml
@@ -38,7 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "arkime.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
+      {{- with .Values.centralViewer.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -104,17 +104,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.centralViewer.containerSecurityContext }}
         securityContext:
-          runAsUser: 65532
-          runAsGroup: 65532
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: arkime-config
         configMap:

--- a/templates/deployment-cont3xt.yaml
+++ b/templates/deployment-cont3xt.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cont3xt.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,7 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "arkime.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
+      {{- with .Values.cont3xt.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -104,17 +105,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.cont3xt.containerSecurityContext }}
         securityContext:
-          runAsUser: 65532
-          runAsGroup: 65532
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: arkime-config
         configMap:
@@ -158,3 +152,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "arkime.fullname" . }}
       app.kubernetes.io/instance: cont3xt
+{{- end -}}

--- a/templates/deployment-wise.yaml
+++ b/templates/deployment-wise.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.wise.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,7 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "arkime.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
+      {{- with .Values.wise.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -104,17 +105,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.wise.containerSecurityContext }}
         securityContext:
-          runAsUser: 65532
-          runAsGroup: 65532
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: arkime-config
         configMap:
@@ -158,3 +152,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "arkime.fullname" . }}
       app.kubernetes.io/instance: wise
+{{- end -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -15,6 +15,7 @@ spec:
   rules:
   - http:
       paths:
+        {{- if .Values.cont3xt.enabled }}
         - path: "/cont3xt/"
           pathType: Prefix
           backend:
@@ -22,6 +23,8 @@ spec:
               name: {{ include "arkime.fullname" . }}-cont3xt
               port:
                 name: arkime-cont3xt
+        {{- end }}
+        {{- if .Values.wise.enabled }}
         - path: "/wise/"
           pathType: Prefix
           backend:
@@ -29,6 +32,7 @@ spec:
               name: {{ include "arkime.fullname" . }}-wise
               port:
                 name: arkime-wise
+        {{- end }}
         - path: "/"
           pathType: Prefix
           backend:

--- a/values.yaml
+++ b/values.yaml
@@ -97,6 +97,7 @@ captureViewerVolumes:
 
 # -- bootstrap is a job that inits the OpenSearch / ElasticSearch database
 bootstrap:
+  enabled: true
   env: []
   envFrom: []
   resources:
@@ -107,23 +108,21 @@ bootstrap:
   extraVolumeMounts: []
   # -- Additional volumes for the controller pod.
   extraVolumes: []
-  nodeSelector:
-    kubernetes.io/os: linux
-  # -- Additional labels to add into metadata.
-  additionalLabels: {}
-  # -- Additional annotations to add into metadata.
-  additionalAnnotations: {}
-  # -- Tolerations to allow the pod to be scheduled to nodes with taints.
-  tolerations: []
-  # -- Specify which Kubernetes scheduler should dispatch the pod.
-  schedulerName: default-scheduler
-  # -- Configure the DNS Policy for the pod
-  dnsPolicy: ClusterFirst
-  # -- Configure DNS Config for the pod
   dnsConfig: {}
   #  options:
   #    - name: ndots
   #      value: "1"
+  containerSecurityContext:
+    runAsUser: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
 
 
 # -- sensor is a daemonset that runs both capture and (optionally) viewer
@@ -204,6 +203,20 @@ centralViewer:
   # -- Additional annotations to add into metadata.
   additionalAnnotations: {}
 
+  podSecurityContext:
+    fsGroup: 65532
+  containerSecurityContext:
+    runAsUser: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
   # -- Tolerations to allow the pod to be scheduled to nodes with taints.
   tolerations: []
   # -- Specify which Kubernetes scheduler should dispatch the pod.
@@ -230,8 +243,16 @@ centralViewer:
     # -- The maximum number of pods that can be unavailable at any given time. Only one of minAvailable or maxUnavailable can be set.
     #maxUnavailable: 0
 
+# -- multies is an optional deployment for MultiES support
+multies:
+  enabled: false
+  replicas: 2
+  command: ["/opt/arkime/bin/docker.sh", "multies", "--insecure", "-n", "centralViewer"]
+  podSecurityContext: {}
+
 # -- cont3xt is a deployment
 cont3xt:
+  enabled: true
   replicas: 2
   command: ["/opt/arkime/bin/docker.sh", "cont3xt", "--insecure"]
   env:
@@ -251,6 +272,20 @@ cont3xt:
   additionalLabels: {}
   # -- Additional annotations to add into metadata.
   additionalAnnotations: {}
+
+  podSecurityContext:
+    fsGroup: 65532
+  containerSecurityContext:
+    runAsUser: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
 
   # -- Tolerations to allow the pod to be scheduled to nodes with taints.
   tolerations: []
@@ -280,6 +315,7 @@ cont3xt:
 
 # -- wise is a deployment
 wise:
+  enabled: true
   replicas: 2
   command: ["/opt/arkime/bin/docker.sh", "wise", "--", "-c", "elasticsearch://usersElasticsearch/arkime_configs/_doc/wise", "--insecure", "--webconfig", "--webcode", "0000"]
   env:
@@ -299,6 +335,20 @@ wise:
   additionalLabels: {}
   # -- Additional annotations to add into metadata.
   additionalAnnotations: {}
+
+  podSecurityContext:
+    fsGroup: 65532
+  containerSecurityContext:
+    runAsUser: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
 
   # -- Tolerations to allow the pod to be scheduled to nodes with taints.
   tolerations: []

--- a/values.yaml
+++ b/values.yaml
@@ -124,7 +124,6 @@ bootstrap:
       drop:
         - ALL
 
-
 # -- sensor is a daemonset that runs both capture and (optionally) viewer
 sensor:
   nodeSelector:
@@ -202,21 +201,12 @@ centralViewer:
   additionalLabels: {}
   # -- Additional annotations to add into metadata.
   additionalAnnotations: {}
-
-  podSecurityContext:
-    fsGroup: 65532
+  podSecurityContext: {}
+    # fsGroup: 65532
   containerSecurityContext:
     runAsUser: 65532
     runAsGroup: 65532
     runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    capabilities:
-      drop:
-        - ALL
-
   # -- Tolerations to allow the pod to be scheduled to nodes with taints.
   tolerations: []
   # -- Specify which Kubernetes scheduler should dispatch the pod.
@@ -243,12 +233,21 @@ centralViewer:
     # -- The maximum number of pods that can be unavailable at any given time. Only one of minAvailable or maxUnavailable can be set.
     #maxUnavailable: 0
 
-# -- multies is an optional deployment for MultiES support
+# -- multies is an optional sidecar container within the centralViewer deployment.   
 multies:
   enabled: false
   replicas: 2
   command: ["/opt/arkime/bin/docker.sh", "multies", "--insecure", "-n", "centralViewer"]
-  podSecurityContext: {}
+  env: []
+  envFrom: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  containerSecurityContext:
+    runAsUser: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
 
 # -- cont3xt is a deployment
 cont3xt:
@@ -273,8 +272,8 @@ cont3xt:
   # -- Additional annotations to add into metadata.
   additionalAnnotations: {}
 
-  podSecurityContext:
-    fsGroup: 65532
+  podSecurityContext: {}
+    # fsGroup: 65532
   containerSecurityContext:
     runAsUser: 65532
     runAsGroup: 65532
@@ -336,8 +335,8 @@ wise:
   # -- Additional annotations to add into metadata.
   additionalAnnotations: {}
 
-  podSecurityContext:
-    fsGroup: 65532
+  podSecurityContext: {}
+    # fsGroup: 65532
   containerSecurityContext:
     runAsUser: 65532
     runAsGroup: 65532


### PR DESCRIPTION
Key changes

1. Optional components

Added enabled flags for bootstrap, cont3xt, and wise.

Allows deploying only the needed Arkime services; cont3xt and wise are disabled by default for a minimal setup.

2. Per-Component security contexts

Replaced hardcoded security contexts with configurable podSecurityContext and containerSecurityContext for each component.

Supports least-privilege deployments and improves compatibility with restrictive platforms like OpenShift.

3. Optional MultiES sidecar

Added a configurable multies sidecar to centralViewer for federated search across multiple ES clusters.

Controlled by multies.enabled (off by default).

4. Dynamic ingress generation

Ingress now only includes paths for cont3xt and wise when they are enabled.